### PR TITLE
Add G4.9 Spindle Dwell Macro

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: MillenniumOS ${{ github.ref_name }}
+          name: ArborCtl ${{ github.ref_name }}
           body: ${{ github.event.head_commit.message }}
           draft: true
           prerelease: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 A daemon macro framework for RepRapFirmware v3.6+, which helps to implement RS485 Spindle Control, Monitoring and Feedback across different VFD types.
 
+## Instructions
+
+ - Download from the RELEASES page, not the code view
+ - Upload the Zip to the system -> files tab in DWC. Do NOT unzip the file locally before upload
+ - Add `M98 P"arborctl.g"` to the end of your `config.g` file.
+   - Your spindle needs to be configured before the include. Make sure this has the correct pins defined (enable, direction, speed) even if these are not connected.
+ - Edit your `daemon.g` file to include `arborctl-daemon.g`. Check `sys/daemon.g.example` for hints on how to do this.
 
 ## Notes
 

--- a/macro/gcodes/G4.9.g
+++ b/macro/gcodes/G4.9.g
@@ -1,0 +1,59 @@
+; G4.9.g: DWELL FOR SPINDLE ACTION
+; USAGE: G4.9 S<spindle> M<max-wait-seconds> P<wait-increment-ms>
+;
+; Wait for the next action on the specified spindle
+; to complete, or until the specified maximum wait time
+; is reached. If no maximum wait time is specified,
+; the default is 30 seconds. After the wait time
+; expires, any active job will be aborted.
+
+; Spindle actions are executed as part of the daemon loop
+; so this command MUST NOT be executed from within that loop.
+
+if { state.thisInput == 9 }
+    abort { "ArborCtl: G4.9 cannot be executed from within the daemon loop!" }
+
+if { !exists(param.S) }
+    abort { "ArborCtl: No spindle specified!" }
+
+if { param.S < 0 || param.S >= limits.spindles || spindles[param.S] == null || spindles[param.S].state == "unconfigured" }
+    abort { "ArborCtl: Spindle ID " ^ param.S ^ " is not valid!" }
+
+var maxWaitMs = { (exists(param.M) ? param.M : 30) * 1000 }
+var waitIncrementMs = { exists(param.P) ? param.P : 250 }
+
+var spindleStatus = { global.arborVFDStatus[param.S] }
+
+if { global.arborVFDStatus[param.S] == null }
+    abort { "ArborCtl: Spindle " ^ param.S ^ " is not managed by ArborCtl!" }
+
+; When a spindle action occurs, the spindle state 'stable'
+; flag is set to false as the action starts, and transitions
+; back to true when the action completes.
+; To wait for the spindle action to complete, we need to wait
+; for a full transition from true to false and back to true.
+
+var desiredState = { false }
+
+; Wait for a maximum of maxWaitMs
+while { (iterations * var.waitIncrementMs) < var.maxWaitMs }
+    ; Check if spindle state is in desired state
+    var wasStable = { global.arborState[param.S][2] }
+    var isStable = { global.arborVFDStatus[param.S][4] }
+
+    ; Spindle state has transitioned to desired state
+    if { var.isStable == var.desiredState && var.wasStable != var.desiredState }
+        ; If spindle is in desired state and state is true,
+        ; the action is complete and we can exit the loop
+        if { var.desiredState == true }
+            echo { "ArborCtl: Spindle " ^ param.S ^ " is stable, action completed!" }
+            M99
+
+        ; Otherwise, the spindle became unstable
+        else
+            set var.desiredState = { true }
+            echo { "ArborCtl: Spindle " ^ param.S ^ " has become unstable, waiting for action to complete..." }
+
+    G4 P{var.waitIncrementMs}
+
+abort { "ArborCtl: Spindle " ^ param.S ^ " did not become stable after " ^ var.maxWait ^ " seconds!" }


### PR DESCRIPTION
G4.9 will wait for an action to occur on spindle `S` before returning. 

If the macro waits for more than `M` seconds then it will abort, cancelling any active job.

The wait increment can be set to `P` ms.

FYI @kohlerj - This new macro is designed to be called from MillenniumOS's `M3.9` and `M5.9` macros when ArborCtl is loaded. It will wait for the spindle to become unstable and then stable again, which should be a good indication that the spindle has reached its desired speed, for example:

```gcode
M3 P0 S12000
G4.9 S0
M5
G4.9 S0
```

I will not get a chance to actually test this in the short term so if you do get a chance to see if this works, then that would be very helpful.

CC @MrSniperPhil 
