### PR TITLE
Enhance spindle control logic to improve change detection

### DIFF
--- a/macro/gcodes/G4.9.g
+++ b/macro/gcodes/G4.9.g
@@ -19,8 +19,8 @@ if { !exists(param.S) }
 if { param.S < 0 || param.S >= limits.spindles || spindles[param.S] == null || spindles[param.S].state == "unconfigured" }
     abort { "ArborCtl: Spindle ID " ^ param.S ^ " is not valid!" }
 
-; Immediately run the spindle control algorithm to make sure that we're actually spinning up the spindle
-M98 P"arborctl/control-spindle.g" S{param.S}
+if { global.arborVFDStatus[param.S] == null }
+    abort { "ArborCtl: Spindle " ^ param.S ^ " is not managed by ArborCtl!" }
 
 var maxWait = { (exists(param.M) ? param.M : 30) }
 var maxWaitMs = var.maxWait * 1000
@@ -28,43 +28,29 @@ var waitIncrementMs = { exists(param.P) ? param.P : 250 }
 var startTime = state.upTime * 1000 + state.msUpTime
 var endTime = var.startTime + var.maxWaitMs
 
-var spindleStatus = { global.arborVFDStatus[param.S] }
+var shouldRun = { (spindles[param.S].state == "forward" || spindles[param.S].state == "reverse") && spindles[param.S].active > 0 }
 
-if { global.arborVFDStatus[param.S] == null }
-    abort { "ArborCtl: Spindle " ^ param.S ^ " is not managed by ArborCtl!" }
-
-; When a spindle action occurs, the spindle state 'stable'
-; flag is set to false as the action starts, and transitions
-; back to true when the action completes.
-; To wait for the spindle action to complete, we need to wait
-; for a full transition from true to false and back to true.
-
-var desiredState = { false }
+; Request change from daemon
+set global.arborState[param.S][5] = { true }
 
 ; Wait for a maximum of maxWaitMs
 while { var.endTime > state.upTime * 1000 + state.msUpTime }
 
-    ; Check if spindle state is in desired state
-    var wasStable = { global.arborState[param.S][2] }
-    var isStable = { global.arborVFDStatus[param.S][4] }
+    G4 P{var.waitIncrementMs}
 
-    if { !var.desiredState && !var.isStable }
-        set var.desiredState = { true }
-        echo { "ArborCtl: Spindle " ^ param.S ^ " is unstable, waiting for action to complete..." }
+    ; Check if daemon consumed the request
+    if { global.arborState[param.S][5] == false }
+        G4 P{var.waitIncrementMs}
 
-    ; Spindle state has transitioned to desired state
-    if { var.isStable == var.desiredState && var.wasStable != var.desiredState }
-        ; If spindle is in desired state and state is true,
-        ; the action is complete and we can exit the loop
-        if { var.desiredState == true }
+        var isStable = global.arborVFDStatus[param.S][4]
+        var isVfdRunning = global.arborVFDStatus[param.S][0]
+
+        if { (var.shouldRun && var.isStable) || (!var.shouldRun && !var.isVfdRunning) }
             echo { "ArborCtl: Spindle " ^ param.S ^ " is stable, action completed!" }
             M99
-
-        ; Otherwise, the spindle became unstable
         else
-            set var.desiredState = { true }
-            echo { "ArborCtl: Spindle " ^ param.S ^ " has become unstable, waiting for action to complete..." }
-
-    G4 P{var.waitIncrementMs}
+            echo { "ArborCtl: Spindle " ^ param.S ^ " request sent, waiting for action to complete..." }
+    else
+        echo { "ArborCtl: Spindle " ^ param.S ^ " waiting for request to be processed..." }
 
 abort { "ArborCtl: Spindle " ^ param.S ^ " did not become stable after " ^ var.maxWait ^ " seconds!" }

--- a/macro/gcodes/G4.9.g
+++ b/macro/gcodes/G4.9.g
@@ -34,7 +34,7 @@ var shouldRun = { (spindles[param.S].state == "forward" || spindles[param.S].sta
 set global.arborState[param.S][5] = { true }
 
 ; Wait for a maximum of approx maxWaitMs + 2*waitIncrementMs
-while { var.waitMs >= var.maxWaitMs }
+while { var.waitMs < var.maxWaitMs }
 
     G4 P{var.waitIncrementMs}
     set var.waitMs = { var.waitMs + var.waitIncrementMs }

--- a/macro/gcodes/M8111.g
+++ b/macro/gcodes/M8111.g
@@ -1,0 +1,7 @@
+; M8111.g
+; This file implements a VFD restart if it is in emergency for the Shihlin-SL3 VFD only
+;
+; Parameters:
+; S - Spindle number
+
+M98 P{"arborctl/restart-spindle.g"} S{param.S}

--- a/macro/gcodes/M8112.g
+++ b/macro/gcodes/M8112.g
@@ -1,0 +1,7 @@
+; M8111.g
+; This file implements a VFD estop
+;
+; Parameters:
+; S - Spindle number
+
+M98 P{"arborctl/estop-spindle.g"} S{param.S}

--- a/macro/private/control-spindle.g
+++ b/macro/private/control-spindle.g
@@ -49,10 +49,9 @@ var commandChange = { global.arborState[param.S][1] }
 var jobRunning    = { job.file.fileName != null && !(state.status == "resuming" || state.status == "pausing" || state.status == "paused") }
 
 ; Check for unexpected instability
-if { (var.wasStable && !var.isStable && !var.commandChange) || var.errorDetected }
+if { (var.vfdRunning && var.wasStable && !var.isStable && !var.commandChange) || var.errorDetected }
     ; Unexpected instability detected - pause job
     echo { "ArborCtl: Spindle " ^ param.S ^ " became unstable!" }
-    echo { "ArborCtl: VFD Running=" ^ var.vfdRunning ^ " WasStable=" ^ var.wasStable ^ " IsStable=" ^ var.isStable ^ " CommandChange=" ^ var.commandChange ^ " ErrorDetected=" ^ var.errorDetected }
     if { var.jobRunning }
         echo { "ArborCtl: Pausing job" }
         M25 ; Pause any running job

--- a/macro/private/estop-spindle.g
+++ b/macro/private/estop-spindle.g
@@ -1,0 +1,36 @@
+; stop-spindle.g - ArborCtl spindle direct stop file
+; This file runs the appropriate VFD control file and handles spindle stability monitoring for one spindle.
+
+if { !exists(param.S) || param.S < 0 || param.S >= limits.spindles | spindles[param.S] == null || spindles[param.S].state == "unconfigured" }
+    echo "ArborCtl: No spindle specified."
+    M99
+
+if { !exists(global.arborctlLdd) || !global.arborctlLdd || !exists(global.arborVFDConfig) || global.arborVFDConfig == null }
+    echo "ArborCtl: Invalid state"
+    M99
+
+; Ensure VFD is configured for this spindle
+if { global.arborVFDConfig[param.S] == null }
+    echo "ArborCtl: No spindle set up."
+    M99
+
+var spindleModel   = { global.arborVFDConfig[param.S][0] }
+var spindleChannel = { global.arborVFDConfig[param.S][1] }
+var spindleAddr    = { global.arborVFDConfig[param.S][2] }
+
+if { var.spindleModel == null || var.spindleChannel == null || var.spindleAddr == null }
+    M99
+
+var modelFile = { "arborctl/" ^ global.arborModelInternalNames[var.spindleModel] ^ "/estop.g" }
+
+if { global.arborSpindleDriverExists[param.S] == null }
+    echo { "ArborCtl: Checking for existence of VFD model file for spindle " ^ param.S }
+    set global.arborSpindleDriverExists[param.S] = { fileexists("0:/sys/" ^ var.modelFile ) }
+
+if { ! global.arborSpindleDriverExists[param.S] }
+    echo { "ArborCtl: VFD model file '0:/sys/" ^ var.modelFile ^ "' not found for spindle " ^ param.S ^ "!" }
+    M99
+
+; Run the appropriate VFD control file for the given spindle
+M98 P{var.modelFile} S{param.S} C{var.spindleChannel} A{var.spindleAddr}
+echo { "ArborCtl: E-Stop command send to spindle" ^ param.S }

--- a/macro/private/restart-spindle.g
+++ b/macro/private/restart-spindle.g
@@ -1,0 +1,36 @@
+; restart-spindle.g - ArborCtl spindle direct restart file
+; This file runs the appropriate VFD control file and handles spindle stability monitoring for one spindle.
+
+if { !exists(param.S) || param.S < 0 || param.S >= limits.spindles | spindles[param.S] == null || spindles[param.S].state == "unconfigured" }
+    echo "ArborCtl: No spindle specified."
+    M99
+
+if { !exists(global.arborctlLdd) || !global.arborctlLdd || !exists(global.arborVFDConfig) || global.arborVFDConfig == null }
+    echo "ArborCtl: Invalid state"
+    M99
+
+; Ensure VFD is configured for this spindle
+if { global.arborVFDConfig[param.S] == null }
+    echo "ArborCtl: No spindle set up."
+    M99
+
+var spindleModel   = { global.arborVFDConfig[param.S][0] }
+var spindleChannel = { global.arborVFDConfig[param.S][1] }
+var spindleAddr    = { global.arborVFDConfig[param.S][2] }
+
+if { var.spindleModel == null || var.spindleChannel == null || var.spindleAddr == null }
+    M99
+
+var modelFile = { "arborctl/" ^ global.arborModelInternalNames[var.spindleModel] ^ "/restart.g" }
+
+if { global.arborSpindleDriverExists[param.S] == null }
+    echo { "ArborCtl: Checking for existence of VFD model file for spindle " ^ param.S }
+    set global.arborSpindleDriverExists[param.S] = { fileexists("0:/sys/" ^ var.modelFile ) }
+
+if { ! global.arborSpindleDriverExists[param.S] }
+    echo { "ArborCtl: VFD model file '0:/sys/" ^ var.modelFile ^ "' not found for spindle " ^ param.S ^ "!" }
+    M99
+
+; Run the appropriate VFD control file for the given spindle
+M98 P{var.modelFile} S{param.S} C{var.spindleChannel} A{var.spindleAddr}
+echo { "ArborCtl: Restart command send to spindle" ^ param.S }

--- a/macro/private/shihlin-sl3/estop.g
+++ b/macro/private/shihlin-sl3/estop.g
@@ -1,0 +1,18 @@
+; shihlin-sl3/estop.g - Shihlin SL3 VFD implementation
+; This file implements a direct stop command for the Shihlin SL3 VFD
+
+if { !exists(param.A) }
+    abort { "ArborCtl: No address specified!" }
+
+if { !exists(param.C) }
+    abort { "ArborCtl: No channel specified!" }
+
+if { !exists(param.S) }
+    abort { "ArborCtl: No spindle specified!" }
+
+var statusAddr   = 4097
+
+M5
+M2600 E0 P{param.C} A{param.A} F6 R{var.statusAddr} B{0,}
+M2600 E0 P{param.C} A{param.A} F6 R{var.freqAddr} B{0,}
+echo { "ArborCtl:  Emergency VFD stop issued! Params: C" ^ param.C ^ " A" ^ param.A }

--- a/macro/private/shihlin-sl3/restart.g
+++ b/macro/private/shihlin-sl3/restart.g
@@ -1,0 +1,21 @@
+; shihlin-sl3/restart.g - Shihlin SL3 VFD implementation
+; This file implements a direct restart command for the Shihlin SL3 VFD
+
+if { !exists(param.A) }
+    abort { "ArborCtl: No address specified!" }
+
+if { !exists(param.C) }
+    abort { "ArborCtl: No channel specified!" }
+
+if { !exists(param.S) }
+    abort { "ArborCtl: No spindle specified!" }
+
+var rebootAddr = 0x1101
+var rebootValue = 0x9696
+
+; Restart the VFD if in emergency
+if { global.arborState[param.S][4] == true }
+    M5
+    echo { "Restarting spindle with "}
+    M2600 E1 P{param.C} A{param.A} F6 R{var.rebootAddr} B{var.rebootValue}
+    echo { "ArborCtl:  Restart issued! Params: C" ^ param.C ^ " A" ^ param.A }

--- a/sys/arborctl-vars.g
+++ b/sys/arborctl-vars.g
@@ -25,7 +25,8 @@ global arborMaxRetries = 3
 ; 2: Previous stability flag (for detecting changes)
 ; 3: Min/max frequency limits from VFD
 ; 4: Error state (true when VFD has an error condition)
-global arborState = { vector(limits.spindles, { null, false, false, null, false }) }
+; 5: Pending request to be acknowledged by control daemon when desired state has been set (e.g. thru M3.9)
+global arborState = { vector(limits.spindles, { null, false, false, null, false, false }) }
 
 ; USER-FRIENDLY VARIABLES - indexed by spindle number
 ; These are public and intended for external script use


### PR DESCRIPTION
So, I changed a lot maybe not knowing fully what you have in mind.  

If the PR makes sense for the SL3 I will extend it to the others VFD obviously

A few points:
- I think the control daemon should always run and always try to get the most up-to-date info from VFD. That is independently of the fact that the spindle should run or not.
- isStable should be reachedSpeed: a separate vfdRunning check is needed if you want to correctly handle the stop detection

It's an open discussion. We can for sure improve upon these changes